### PR TITLE
Convert cookbook to Centos 7.1

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -14,11 +14,11 @@ provisioner:
   name: chef_solo
 
 platforms:
-- name: centos-6.6
+- name: centos-7.1
   driver_plugin: openstack
   driver_config:
     username: centos
-    image_ref: "CentOS 6.6"
+    image_ref: "CentOS 7.1"
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,7 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: centos-6.6
+  - name: centos-7.1
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,5 +24,3 @@ default['formsender']['conf_log_addr'] = '/dev/log'
 
 default['formsender']['error_log'] = '/var/log/nginx/formsender/error.log'
 default['formsender']['access_log'] = '/var/log/nginx/formsender/access.log'
-
-override['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip2.7"

--- a/recipes/_centos.rb
+++ b/recipes/_centos.rb
@@ -1,5 +1,0 @@
-include_recipe 'yum-ius'
-
-%w(python27 python27-devel python27-pip).each do |pkg|
-  package pkg
-end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'formsender::_centos' if platform_family?('rhel')
 include_recipe 'git'
 
 python_webapp 'formsender' do

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -12,10 +12,10 @@ describe port(80) do
 end
 
 describe service('formsender') do
-  it { should be_running }
+  it { should be_running.under('supervisor') }
 end
 
-describe service('gunicorn') do
+describe service('supervisor') do
   it { should be_running }
 end
 


### PR DESCRIPTION
- Updated to Centos 7.1
- Removed Python 2.7 install
- Updated tests

Test output: 

```
-----> serverspec installed (version 2.24.0)
       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -I/tmp/busser/gems/gems/rspec-support-3.3.0/lib:/tmp/busser/gems/gems/rspec-core-3.3.2/lib /opt/chef/embedded/bin/rspec --pattern /tmp/busser/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/busser/suites/serverspec

       Port "8080"
         should be listening

       Port "80"
         should be listening

       Service "formsender"
         should be running

       Service "supervisor"
         should be running

       Service "nginx"
         should be running

       Finished in 1.12 seconds (files took 0.55068 seconds to load)
       5 examples, 0 failures

       Finished verifying <default-centos-71> (0m14.42s).
-----> Destroying <default-centos-71>...
       OpenStack instance <0b95e305-ddf5-48fb-82d3-39c9e9847bb1> destroyed.
       Finished destroying <default-centos-71> (0m1.07s).
       Finished testing <default-centos-71> (3m35.49s).
-----> Kitchen is finished. (3m37.95s)
```
