### PR TITLE
Update for Multiple Emails

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default['formsender']['venv_owner'] = 'root'
 default['formsender']['venv_group'] = 'root'
 
 default['formsender']['debug'] = false
-default['formsender']['git_branch'] = 'master'
+default['formsender']['git_branch'] = 'develop'
 default['formsender']['repository'] = 'https://github.com/osuosl/formsender'
 
 default['formsender']['server_name'] = node['fqdn']
@@ -12,6 +12,8 @@ default['formsender']['gunicorn_port'] = 8080
 default['formsender']['subdirectory'] = '' # add trailing slash if in a subdir
 
 default['formsender']['conf_email'] = 'support@osuosl.org'
+default['formsender']['conf_email_sup'] = 'support@osuosl.org'
+default['formsender']['conf_email_root'] = 'root@osuosl.org'
 default['formsender']['conf_token'] = \
 '15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS'
 default['formsender']['conf_ceiling'] = 10

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default['formsender']['venv_owner'] = 'root'
 default['formsender']['venv_group'] = 'root'
 
 default['formsender']['debug'] = false
-default['formsender']['git_branch'] = 'develop'
+default['formsender']['git_branch'] = 'master'
 default['formsender']['repository'] = 'https://github.com/osuosl/formsender'
 
 default['formsender']['server_name'] = node['fqdn']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,9 +11,9 @@ default['formsender']['server_name'] = node['fqdn']
 default['formsender']['gunicorn_port'] = 8080
 default['formsender']['subdirectory'] = '' # add trailing slash if in a subdir
 
-default['formsender']['conf_email'] = 'support@osuosl.org'
-default['formsender']['conf_email_sup'] = 'support@osuosl.org'
-default['formsender']['conf_email_root'] = 'root@osuosl.org'
+default['formsender']['emails']['default'] = 'support@osuosl.org'
+default['formsender']['emails']['support'] = 'support@osuosl.org'
+default['formsender']['emails']['root'] = 'root@osuosl.org'
 default['formsender']['conf_token'] = \
 '15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS'
 default['formsender']['conf_ceiling'] = 10

--- a/templates/default/conf.py.erb
+++ b/templates/default/conf.py.erb
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 EMAIL = <%= '{' + node['formsender']['emails'].map {|k,v| "'#{k}': '#{v}'"}.join(',') + '}' %>
-TOKN = "<%= node['formsender']['conf_token'] %>"
+TOKEN = "<%= node['formsender']['conf_token'] %>"
 CEILING = <%= node['formsender']['conf_ceiling'] %>
 DUPLICATE_CHECK_TIME = <%= node['formsender']['conf_duplication_time'] %>
 HOST = "<%= node['formsender']['conf_host'] %>"

--- a/templates/default/conf.py.erb
+++ b/templates/default/conf.py.erb
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
 
-EMAIL = {'default': "<%= node['formsender']['conf_email'] %>",
-         'support': "<%= node['formsender']['conf_email_sup'] %>",
-         'root': "<%= node['formsender']['conf_email_root'] %>"}
+EMAIL = <%= '{' + node['formsender']['emails'].map {|k,v| "'#{k}': '#{v}'"}.join(',') + '}' %>
 TOKN = "<%= node['formsender']['conf_token'] %>"
 CEILING = <%= node['formsender']['conf_ceiling'] %>
 DUPLICATE_CHECK_TIME = <%= node['formsender']['conf_duplication_time'] %>

--- a/templates/default/conf.py.erb
+++ b/templates/default/conf.py.erb
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
 
-EMAIL = "<%= node['formsender']['conf_email'] %>"
+EMAIL = {'default': "<%= node['formsender']['conf_email'] %>",
+         'support': "<%= node['formsender']['conf_email_sup'] %>",
+         'root': "<%= node['formsender']['conf_email_root'] %>"}
 TOKN = "<%= node['formsender']['conf_token'] %>"
 CEILING = <%= node['formsender']['conf_ceiling'] %>
 DUPLICATE_CHECK_TIME = <%= node['formsender']['conf_duplication_time'] %>

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -24,6 +24,9 @@ describe service('nginx') do
 end
 
 describe file('/opt/formsender/source/conf.py') do
+  default = "'default': 'support@osuosl.org'"
+  support = "'support': 'support@osuosl.org'"
+  root    = "'root': 'root@osuosl.org'"
   it { should exist }
-  its(:content) { should match /EMAIL = {'default': 'support@osuosl.org','support': 'support@osuosl.org','root': 'root@osuosl.org'}/ }
+  its(:content) { should match(/EMAIL = {#{default},#{support},#{root}}/) }
 end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -22,3 +22,8 @@ end
 describe service('nginx') do
   it { should be_running }
 end
+
+describe file('/opt/formsender/source/conf.py') do
+  it { should exist }
+  its(:content) { should match /EMAIL = {'default': 'support@osuosl.org','support': 'support@osuosl.org','root': 'root@osuosl.org'}/ }
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -24,9 +24,9 @@ describe service('nginx') do
 end
 
 describe file('/opt/formsender/source/conf.py') do
-  default = "'default': 'support@osuosl.org'"
-  support = "'support': 'support@osuosl.org'"
-  root    = "'root': 'root@osuosl.org'"
   it { should exist }
-  its(:content) { should match(/EMAIL = {#{default},#{support},#{root}}/) }
+  it do
+    should contain("EMAIL = {'default': 'support@osuosl.org','support': \
+'support@osuosl.org','root': 'root@osuosl.org'}")
+  end
 end


### PR DESCRIPTION
Update formsender cookbook to include configurable email functionality.

Result of `tkc verify`:

```
-----> serverspec installed (version 2.24.2)
       /opt/chef/embedded/bin/ruby -I/tmp/busser/suites/serverspec -I/tmp/busser/gems/gems/rspec-support-3.3.0/lib:/tmp/busser/gems/gems/rspec-core-3.3.2/lib /opt/chef/embedded/bin/rspec --pattern /tmp/busser/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/busser/suites/serverspec

       Port "8080"
         should be listening

       Port "80"
         should be listening

       Service "formsender"
         should be running

       Service "supervisor"
         should be running

       Service "nginx"
         should be running

       Finished in 1.22 seconds (files took 0.54515 seconds to load)
       5 examples, 0 failures

       Finished verifying <default-centos-71> (0m8.29s).
-----> Kitchen is finished. (0m19.37s)
```

Upon ssh-ing into the box I ran the formsender tests:

```
(venv)[root@defaultcentos71-mrsj-silver-l8stawu source]# make tests
python tests.py
..................................
----------------------------------------------------------------------
Ran 34 tests in 0.887s

OK
```
